### PR TITLE
Add finishStopWatch call to restartTest()

### DIFF
--- a/src/wordsPerMinTest.ts
+++ b/src/wordsPerMinTest.ts
@@ -65,9 +65,9 @@ export class wordsPerMinTest  {
         this.averageWPM = 0;
         this.lastTenAvWPM = 0;
         this.secTimer = 0;
-        this.started = false;
         this.wordCount = 0;
         this.wordTimes = [];
+        this.finishStopWatch();
         if (this.usingRandomChar) {
             this.generateChars(1000);
         }


### PR DESCRIPTION
The stopwatch was not being reset when restartTest() was called.
This PR is to enable https://github.com/Scoombe/react-typing/issues/3 and goes with https://github.com/Scoombe/react-typing/pull/5